### PR TITLE
Fix numbering in Pre-run steps on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ready to help test solutions.
 ## Pre-run Steps
 
 This only lists distros that are known to have issues. Yours might work perfectly, or it might break. The only way to 
-find out is try!
+find out is to try!
 
 ### 64-Bit Debian & Ubuntu
 These instructions have been reported to work with the following distros:

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ then you need to enable compatibility for 32 bit binaries. If your distro isn't 
 ready to help test solutions.
 
 
-### Pre-run Steps
+## Pre-run Steps
 
 This only lists distros that are known to have issues. Yours might work perfectly, or it might break. The only way to 
 find out is try!
 
-#### 64-Bit Debian & Ubuntu
+### 64-Bit Debian & Ubuntu
 These instructions have been reported to work with the following distros:
 * Debian 10 Buster, 64 Bit
 * Ubuntu 20.04 LTS, 64 Bit

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ information on what you need to install beforehand.
 1. At least 75 mb of free space on the partition you're installing to
 2. 32-bit compatibility enabled, see the the **Pre-run Steps** section
 
-### Running the script
+### Installing the game
 
 1. Put the script in a directory you'd like to install DS into. 
 2. Make sure the script is set to executable, either through your file manager's GUI,

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ You'll need to make sure that `p7zip-full` and `zstd` are installed as not all d
 
     sudo apt-get install p7zip-full zstd
 
-#### 1. Add i386 architecture, update apt, & restart
+#### 2. Add i386 architecture & update apt
 Add the 386 architecture
 
     sudo dpkg --add-arch i386
@@ -79,7 +79,7 @@ If everything worked correctly, running `dpkg --print-foreign-architectures` sho
     vagrant@buster:~$ dpkg --print-foreign-architectures
     i386
 
-#### 2. Install additional dependencies
+#### 3. Install additional dependencies
 
 These are needed for the game to run.
 


### PR DESCRIPTION
There are some typos and an obsolete mention of a restart in a section title. This PR fixes those.