### PR TITLE
Add first draft of a local server to test downloader

### DIFF
--- a/local_test_server
+++ b/local_test_server
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script is for testing the dstation-2020 script. It isn't
+# helpful for regular users who want to install Docking Station.
+
+if [[ -z `which python3` ]] ; then
+    echo "Python 3 is required to run the dummy server"
+else
+    # serve the local directory over port 8000
+    python3 -m http.server 8000
+fi


### PR DESCRIPTION
This is a very simple version of the script that assumes the tester will download the files themselves. Given you added loading from local files instead of redownloading every time, this ticket (#3 ) isn't very high priority.